### PR TITLE
Use the correct color from the palette for the info box header

### DIFF
--- a/list_controller.cpp
+++ b/list_controller.cpp
@@ -25,7 +25,7 @@ void ListController::InnerView::didBecomeFirstResponder() {
 }
 
 ListController::ListController(Responder * parentResponder) :
-  StackViewController(parentResponder, &m_innerView, Palette::PurpleBright, Palette::PurpleDark),
+  StackViewController(parentResponder, &m_innerView, Palette::BannerFirstText, Palette::BannerFirstBackground),
   m_innerView(this),
   m_parent(parentResponder)
 {


### PR DESCRIPTION
Currently, the box uses PurpleBright for text and PurpleDark for the background which doesn't match the rest of the firmware.